### PR TITLE
Fix ParticleSystem for mouse glitter trial

### DIFF
--- a/Assets/Prefabs/CursorTrial.prefab
+++ b/Assets/Prefabs/CursorTrial.prefab
@@ -4781,7 +4781,7 @@ ParticleSystemRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 50
   m_RenderMode: 0
   m_SortMode: 0
   m_MinParticleSize: 0

--- a/Assets/Scripts/QuestManager.cs
+++ b/Assets/Scripts/QuestManager.cs
@@ -31,11 +31,8 @@ public class QuestManager : MonoBehaviour
         FindObjectOfType<AudioManager>().StopEffect("Open");
         FindObjectOfType<AudioManager>().PlayEffect("Open");
         isOpen = !isOpen;
-        //AcceptedQuestWindow.SetActive(isOpen);
         animator.SetBool("IsOpen", isOpen);
         selectedQuestWindow.gameObject.SetActive(false);
-        //if (FindObjectOfType<SelectedQuestWindow>())
-        //    FindObjectOfType<SelectedQuestWindow>().gameObject.SetActive(false);
     }
 
     public void Close()


### PR DESCRIPTION
Particles are now set to instantiate in front of all `GameObjects` and behind the cursor.